### PR TITLE
Hello , 

### DIFF
--- a/assignment1/Linear classifier.ipynb
+++ b/assignment1/Linear classifier.ipynb
@@ -302,8 +302,8 @@
     "\n",
     "#Test batch_size = 3\n",
     "batch_size = 3\n",
-    "predictions = np.zeros((batch_size, 3))\n",
-    "target_index = np.ones(batch_size, np.int)\n",
+    "predictions = np.random.randint(-1, 3, size=(batch_size, num_classes)).astype(np.float)\n",
+    "target_index = np.random.randint(0, num_classes, size=(batch_size, 1)).astype(np.int)\n",
     "check_gradient(lambda x: linear_classifer.softmax_with_cross_entropy(x, target_index), predictions)"
    ]
   },

--- a/assignment1/linear_classifer.py
+++ b/assignment1/linear_classifer.py
@@ -46,6 +46,7 @@ def cross_entropy_loss(probs, target_index):
         return -np.log(probs[target_index])
     else:
         #batch
+        target_index = np.squeeze(target_index)
         return -np.sum(np.log(probs[np.arange(len(probs)), target_index]))
 
 
@@ -72,6 +73,7 @@ def softmax_with_cross_entropy(predictions, target_index):
     if len(predictions.shape) == 1:
         dprediction[target_index] = dprediction[target_index] - 1
     else:
+        target_index = np.squeeze(target_index)
         dprediction[np.arange(len(dprediction)), target_index] -=1
  
     return loss, dprediction


### PR DESCRIPTION
Your code is amazing , I learn a lot and I detected an error due to using zeros samples. When real numbers are used for 3 sample batch and apply gradient check it fails. I managed to detect source of error is your 

` dprediction[np.arange(len(dprediction)), target_index] -= 1`
 if target_index shape is (3,1) you get different matrix than you need.We need (3, ) shaped target_index. So I added this line above 
`target_index = np.squeeze(target_index)`
I did the same thing for both softmax_with_cross_entropy  and  cross_entropy functions